### PR TITLE
Fixed warning if there are no queries at all

### DIFF
--- a/src/Analytics/QueryAnalyzer.php
+++ b/src/Analytics/QueryAnalyzer.php
@@ -14,7 +14,7 @@ class QueryAnalyzer
 	/**
 	 * @var Query[]
 	 */
-	private $queries;
+	private $queries = [];
 
 	/**
 	 * @var Query[]


### PR DESCRIPTION
If there are no queries at all, both the ```getIdenticalQueries()``` and ```getSimilarQueries()``` trigger a warning that "Invalid argument supplied for foreach()" which is true because it's ```NULL``` by default.